### PR TITLE
Us#225177 improve octane timesheet integration

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/octane/OctaneConstants.java
+++ b/src/com/ppm/integration/agilesdk/connector/octane/OctaneConstants.java
@@ -127,4 +127,12 @@ public class OctaneConstants {
     public static final String KEY_FIELD_LAST_MODIFIED = "last_modified";
     
     public static final String KEY_FIELD_NAME_DEFAULT_VALUE = "default name value";
+
+    public static final String TS_GROUP_BY = "TS_GROUP_BY";
+
+    public static final String TS_GROUP_BY_RELEASE = "TS_GROUP_BY_RELEASE";
+
+    public static final String TS_GROUP_BY_WORKSPACE = "TS_GROUP_BY_WORKSPACE";
+
+    public static final String TS_GROUP_BY_BACKLOG_ITEM = "TS_GROUP_BY_BACKLOG_ITEM";
 }

--- a/src/com/ppm/integration/agilesdk/connector/octane/OctaneIntegrationConnector.properties
+++ b/src/com/ppm/integration/agilesdk/connector/octane/OctaneIntegrationConnector.properties
@@ -108,3 +108,9 @@ GROUP_BACKLOG_STRUCTURE = Backlog / Epic / Feature
 PERCENT_COMPLETE_WORK = % Work Complete
 PERCENT_COMPLETE_STORY_POINTS = % Story Points Done
 PERCENT_COMPLETE_ITEMS_COUNT = % Backlog Items Count Done
+
+TS_GROUP_BY = Group timesheet lines by
+TS_GROUP_BY_WORKSPACE = Workspaces
+TS_GROUP_BY_RELEASE = Releases
+TS_GROUP_BY_BACKLOG_ITEM = Backlog Items
+TS_NO_RELEASE_LABEL = No Release Set

--- a/test/com/ppm/integration/agilesdk/connector/octane/ClientPublicAPITest.java
+++ b/test/com/ppm/integration/agilesdk/connector/octane/ClientPublicAPITest.java
@@ -89,7 +89,7 @@ public class ClientPublicAPITest {
             for (WorkSpace workSpace : workspacesAll) {
                 List<TimesheetItem> timeSheets = client.getTimeSheetData(Integer.parseInt(shareSpace.id),
                         values.get(OctaneConstants.KEY_USERNAME), startDateStr, endDateStr,
-                        Integer.parseInt(workSpace.id));
+                        Integer.parseInt(workSpace.id), groupBy);
                 Map<String, ArrayList<TimesheetItem>> releaseTimesheet =
                         new HashMap<String, ArrayList<TimesheetItem>>();
                 for (TimesheetItem timeItem : timeSheets) {


### PR DESCRIPTION
- Adding timesheet option to group lines by workspace/release/backlog items
- Better error management if client ID is not workspace admin of all workspaces (new workspaces are skipped)
- Added support for auto-mapping timesheet lines