### PR TITLE
Deloitte Octane Sync issues: 'No Sprint' showing up even when all wor…

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/octane/OctaneWorkPlanIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/octane/OctaneWorkPlanIntegration.java
@@ -662,6 +662,14 @@ public class OctaneWorkPlanIntegration extends WorkPlanIntegration implements Fu
                 final Map<String, Map<String, List<GenericWorkItem>>> workItemsPerReleaseIdAndSprintId = new HashMap<>();
 
                 for (GenericWorkItem wi : workItems) {
+
+                    if (!wi.isDefectOrStory()) {
+                        // We don't want to keep epics and features in the release backlog.
+                        // Also, since they don't have Release (Epic)  or Sprint (Epic/Feature) set, they'll create
+                        // No Sprint/No Release tasks in WP even when not needed.
+                        continue;
+                    }
+
                     String releaseId = wi.getReleaseId();
                     String sprintId = wi.getSprintId();
 

--- a/src/com/ppm/integration/agilesdk/connector/octane/model/GenericWorkItem.java
+++ b/src/com/ppm/integration/agilesdk/connector/octane/model/GenericWorkItem.java
@@ -173,4 +173,18 @@ public class GenericWorkItem {
     public Integer getAggregatedStoryPoints() {
         return getInteger("actual_story_points");
     }
+
+    public boolean isDefectOrStory() {
+        switch(getSubType()) {
+            case "defect":
+                return true;
+            case "story":
+                return true;
+            case "quality_story":
+                return true;
+            default:
+                return false;
+        }
+
+    }
 }

--- a/src/com/ppm/integration/agilesdk/connector/octane/model/workplan/OctaneWorkItemExternalTask.java
+++ b/src/com/ppm/integration/agilesdk/connector/octane/model/workplan/OctaneWorkItemExternalTask.java
@@ -88,7 +88,6 @@ public class OctaneWorkItemExternalTask extends BaseOctaneExternalTask {
                 } else {
                     return null;
                 }
-
             }
 
             @Override
@@ -125,9 +124,16 @@ public class OctaneWorkItemExternalTask extends BaseOctaneExternalTask {
                     return 100;
                 }
 
-                if (OctaneConstants.PERCENT_COMPLETE_STORY_POINTS.equals(context.percentComplete) || OctaneConstants.PERCENT_COMPLETE_ITEMS_COUNT.equals(context.percentComplete)) {
-                    // If we are in story points mode or backlog items count mode and task is not completed, then it's zero percent.
+                if (!(TaskStatus.ON_HOLD.equals(getStatus()) || TaskStatus.IN_PROGRESS.equals(getStatus()))) {
+                    // Task is READY, IN PLANNING, etc, but is not in progress.
                     return 0;
+                }
+
+                // Here we're IN_PROGRESS
+
+                if (OctaneConstants.PERCENT_COMPLETE_STORY_POINTS.equals(context.percentComplete) || OctaneConstants.PERCENT_COMPLETE_ITEMS_COUNT.equals(context.percentComplete)) {
+                    // If we are in story points mode or backlog items count mode and task is not completed, then it's 0% if no actual effort and 1% if any actual effort.
+                    return workItem.getInvestedHours() > 0d ? 1d : 0d;
                 }
 
                 if (workItem.getRemainingHours() + workItem.getInvestedHours() == 0) {

--- a/src/com/ppm/integration/agilesdk/connector/octane/model/workplan/WorkDrivenPercentCompleteExternalTask.java
+++ b/src/com/ppm/integration/agilesdk/connector/octane/model/workplan/WorkDrivenPercentCompleteExternalTask.java
@@ -38,7 +38,7 @@ public class WorkDrivenPercentCompleteExternalTask extends ExternalTask {
     }
 
     /**
-     * Use this constructor for Summary tasks, that have some values for work done & work remaining.
+     * Use this constructor for Leaf tasks, that have some values for work done & work remaining.
      * If passing null, we consider it to be zero.
      */
     public static WorkDrivenPercentCompleteExternalTask forLeafTask(ExternalTask wrappedTask, double workDone, double workRemaining) {
@@ -46,6 +46,7 @@ public class WorkDrivenPercentCompleteExternalTask extends ExternalTask {
     }
 
     @Override public Double getPercentCompleteOverrideValue() {
+
         double done = getWorkDone();
         double remaining = getWorkRemaining();
 
@@ -54,7 +55,8 @@ public class WorkDrivenPercentCompleteExternalTask extends ExternalTask {
             if (TaskStatus.COMPLETED.equals(getStatus()) || TaskStatus.CANCELLED.equals(getStatus())) {
                 return 100d;
             } else {
-                return 0d;
+                // No problem to have 0% complete for a task in progress even if no effort exists as this percent complete is for the override and not the individual actuals.
+                 return 0d;
             }
         }
 


### PR DESCRIPTION
…k items have sprint, and actual start date ignoring sprint info when not using % work complete